### PR TITLE
Added tests and a couple small fixes; returning an error if the specified pause duration is zero

### DIFF
--- a/app/utils/commands.js
+++ b/app/utils/commands.js
@@ -253,19 +253,19 @@ class Command {
 function parseDuration (input) {
   if (input.match(/^\d+$/) != null) {
     const mins = Number.parseInt(input)
-    return mins * minToMs
+    const result = mins * minToMs
+    return result > 0 ? result : -1
   }
 
-  var result = input.toLowerCase().match(/(?:(\d+h))?(?:(\d+m))?/)
-  if (result === null || result[0] === '') {
+  const parts = input.toLowerCase().match(/^(?:(\d+h))?(?:(\d+m))?$/)
+  if (parts === null || parts[0] === '') {
     return -1
   }
 
-  const hours = result[1] ? Number.parseInt(result[1].slice(0, -1)) : 0
-  const minutes = result[2] ? Number.parseInt(result[2].slice(0, -1)) : 0
-  const total = hours * minToMs * 60 + minutes * minToMs
-
-  return isNaN(total) ? -1 : total
+  const hours = parts[1] ? Number.parseInt(parts[1].slice(0, -1)) : 0
+  const minutes = parts[2] ? Number.parseInt(parts[2].slice(0, -1)) : 0
+  const result = hours * minToMs * 60 + minutes * minToMs
+  return isNaN(result) || result <= 0 ? -1 : result
 }
 
 const minToMs = 60000

--- a/app/utils/commands.js
+++ b/app/utils/commands.js
@@ -257,13 +257,13 @@ function parseDuration (input) {
     return result > 0 ? result : -1
   }
 
-  const parts = input.toLowerCase().match(/^(?:(\d+h))?(?:(\d+m))?$/)
+  const parts = input.toLowerCase().match(/^(?:(\d+)h)?(?:(\d+)m)?$/)
   if (parts === null || parts[0] === '') {
     return -1
   }
 
-  const hours = parts[1] ? Number.parseInt(parts[1].slice(0, -1)) : 0
-  const minutes = parts[2] ? Number.parseInt(parts[2].slice(0, -1)) : 0
+  const hours = parts[1] ? Number.parseInt(parts[1]) : 0
+  const minutes = parts[2] ? Number.parseInt(parts[2]) : 0
   const result = hours * minToMs * 60 + minutes * minToMs
   return isNaN(result) || result <= 0 ? -1 : result
 }

--- a/app/utils/commands.js
+++ b/app/utils/commands.js
@@ -46,14 +46,14 @@ const allCommands = {
     description: 'Resume from a pause'
   },
   toggle: {
-    description: 'Toggle breaks between resume/paused'
+    description: 'Pause/unpause breaks'
   },
   mini: {
-    description: 'Skips to and customize next Mini Break',
+    description: 'Skip to the Mini Break, customize it',
     options: [allOptions.title, allOptions.noskip]
   },
   long: {
-    description: 'Skips to and customize next Long Break',
+    description: 'Skip to the Long Break, customize it',
     options: [allOptions.text, allOptions.title, allOptions.noskip]
   }
 }
@@ -75,16 +75,16 @@ const allExamples = [{
   description: 'Pause breaks for one hour and twenty minutes'
 },
 {
-  cmd: 'stretchly mini -T "Stretch up !"',
-  description: 'Skips to next Mini Break with "Stretch up!" title'
+  cmd: 'stretchly mini -T "Stretch up!"',
+  description: 'Start a Mini Break, with the title "Stretch up!"'
 },
 {
-  cmd: 'stretchly long -T "Stretch up !" --noskip',
-  description: 'Sets next Break title to "Stretch up!"'
+  cmd: 'stretchly long -T "Stretch up!" --noskip',
+  description: 'Set the next Break\'s title to "Stretch up!"'
 },
 {
-  cmd: 'stretchly long -T "Stretch up !" -t "Go stretch !"',
-  description: 'Skips to next long break, sets title to "Stretch up !" and text to "Go stretch !"'
+  cmd: 'stretchly long -T "Stretch up!" -t "Go stretch!"',
+  description: 'Start a long break, with the title "Stretch up!" and text "Go stretch!"'
 }]
 
 // Parse cmd line, check if valid and put variables in a dedicated object

--- a/test/commands.js
+++ b/test/commands.js
@@ -31,11 +31,14 @@ describe('commands', () => {
   })
 
   it('should get options from a command', () => {
-    const opts = ['-T', 'test', '-n']
-    const cmd = new Command(['mini'], '1.2.3')
-    const options = cmd.getOpts(opts)
-    options.title.should.be.equal('test')
-    options.noskip.should.be.equal(true)
+    const cmd = new Command(['mini', '-T', 'test', '-n'], '1.2.3')
+    cmd.options.title.should.be.equal('test')
+    cmd.options.noskip.should.be.equal(true)
+  })
+
+  it('includes only the specified options in the resulting options object', () => {
+    const cmd = new Command(['mini', '-T', 'test'], '1.2.3')
+    cmd.options.should.deep.equal({ title: 'test' })
   })
 
   it.skip('errors out when an invalid command is given', () => {

--- a/test/commands.js
+++ b/test/commands.js
@@ -23,7 +23,7 @@ describe('commands', () => {
     cmd.options.duration.should.be.equal('until-morning')
   })
 
-  it('should drop all flags before command', () => {
+  it('should drop all flags before the command', () => {
     const input = ['--some-electron-flag=value', 'mini', '-T', 'test', '--noskip']
     const cmd = new Command(input, '1.2.3')
     cmd.command.should.be.equal('mini')
@@ -38,13 +38,77 @@ describe('commands', () => {
     options.noskip.should.be.equal(true)
   })
 
-  it('should parse a duration from args', () => {
-    const input = ['pause', '-d', '60m']
-    const cmd = new Command(input, '1.2.3')
-    cmd.durationToMs(null).should.be.equal(3600000)
+  it.skip('errors out when an invalid command is given', () => {
+    const cmd = new Command(['foo'], '1.2.3')
+    console.log(cmd.command)
   })
 
-  it('should return -1 if duration not formated correcly', () => {
+  it.skip('errors out when an invalid argument is given for a command', () => {
+    const cmd = new Command(['help', '--bar', 'baz'], '1.2.3')
+    console.log(cmd.command)
+  })
+
+  it('parses a number duration as the number of minutes to pause', () => {
+    const input = ['pause', '-d', '60']
+    const cmd = new Command(input, '1.2.3')
+    cmd.durationToMs(null).should.be.equal(60 * 60 * 1000)
+  })
+
+  it('parses a duration argument with hours and minutes', () => {
+    const input = ['pause', '-d', '4h39m']
+    const cmd = new Command(input, '1.2.3')
+    cmd.durationToMs(null).should.be.equal(4 * 60 * 60 * 1000 + 39 * 60 * 1000)
+  })
+
+  it('parses a duration argument with hours and minutes in the upper case', () => {
+    const input = ['pause', '-d', '4H39M']
+    const cmd = new Command(input, '1.2.3')
+    cmd.durationToMs(null).should.be.equal(4 * 60 * 60 * 1000 + 39 * 60 * 1000)
+  })
+
+  it('parses a duration argument with just the minutes', () => {
+    const input = ['pause', '-d', '60m']
+    const cmd = new Command(input, '1.2.3')
+    cmd.durationToMs(null).should.be.equal(60 * 60 * 1000)
+  })
+
+  it('parses a duration argument with just the hours', () => {
+    const input = ['pause', '-d', '184h']
+    const cmd = new Command(input, '1.2.3')
+    cmd.durationToMs(null).should.be.equal(184 * 60 * 60 * 1000)
+  })
+
+  it('returns -1 if there\'s extra text in the duration argument', () => {
+    new Command(['pause', '-d', 'foo4h39mbar'], '1.2.3').durationToMs(null).should.be.equal(-1)
+    new Command(['pause', '-d', 'foo4h39m'], '1.2.3').durationToMs(null).should.be.equal(-1)
+    new Command(['pause', '-d', '4h39mbar'], '1.2.3').durationToMs(null).should.be.equal(-1)
+  })
+
+  it('returns -1 if a number duration argument is zero', () => {
+    const input = ['pause', '-d', '0']
+    const cmd = new Command(input, '1.2.3')
+    cmd.durationToMs(null).should.be.equal(-1)
+  })
+
+  it('returns -1 if the duration argument with the hours and minutes evaluates to zero', () => {
+    const input = ['pause', '-d', '0h0m']
+    const cmd = new Command(input, '1.2.3')
+    cmd.durationToMs(null).should.be.equal(-1)
+  })
+
+  it('returns -1 if the duration argument with just the minutes evaluates to zero', () => {
+    const input = ['pause', '-d', '0m']
+    const cmd = new Command(input, '1.2.3')
+    cmd.durationToMs(null).should.be.equal(-1)
+  })
+
+  it('returns -1 if the duration argument with just the hours evaluates to zero', () => {
+    const input = ['pause', '-d', '0h']
+    const cmd = new Command(input, '1.2.3')
+    cmd.durationToMs(null).should.be.equal(-1)
+  })
+
+  it('should return -1 if the duration argument is not in a known format', () => {
     const input = ['pause', '-d', '10i20k']
     const cmd = new Command(input, '1.2.3')
     cmd.durationToMs(null).should.be.equal(-1)


### PR DESCRIPTION
I permitted myself to change the descriptions of some options—IMO they read a bit better this way, and the verbs are unified.

I added tests for when an invalid command or an invalid argument are given, but it turns out the code does pretty much nothing in this case (aside from writing to the console), so not sure what to do with them. IMO the code should throw an error and let calling code exit properly, or at least return values signaling an error—it's cleaner that way from the future-proofing standpoint than returning invalid values.